### PR TITLE
Add function modules

### DIFF
--- a/chap1/1.3.3.ipynb
+++ b/chap1/1.3.3.ipynb
@@ -44,7 +44,7 @@
    },
    "outputs": [],
    "source": [
-    "def is_close_enough(x, y): return abs(x - y) < 1e-3"
+    "def is_close_enough(x, y, epsilon=1e-3): return abs(x - y) < epsilon"
    ]
   },
   {
@@ -107,8 +107,7 @@
     "    elif is_negative(b_value) and is_positive(a_value):\n",
     "        return search(f, b, a)\n",
     "    else:\n",
-    "        print('Values are not of opposite sign.')\n",
-    "        raise ValueError"
+    "        raise ValueError('Values are not of opposite sign')"
    ]
   },
   {
@@ -140,15 +139,15 @@
      "name": "stdout",
      "output_type": "stream",
      "text": [
-      "Values are not of opposite sign.\n"
+      "Values are not of opposite sign\n"
      ]
     }
    ],
    "source": [
     "try:\n",
     "    print(half_interval_method(math.sin, 2, 3))\n",
-    "except ValueError:\n",
-    "    pass"
+    "except ValueError as e:\n",
+    "    print(e)"
    ]
   },
   {
@@ -186,15 +185,10 @@
    },
    "outputs": [],
    "source": [
-    "def fixed_point(f, first_guess):\n",
-    "    tolerance = 1e-5\n",
-    "\n",
-    "    def is_close_enough(v1, v2):\n",
-    "        return abs(v1 - v2) < tolerance\n",
-    "\n",
+    "def fixed_point(f, first_guess, tolerance=1e-5):\n",
     "    def try_next(guess):\n",
     "        next_val = f(guess)\n",
-    "        if is_close_enough(guess, next_val):\n",
+    "        if is_close_enough(guess, next_val, tolerance):\n",
     "            return next_val\n",
     "        else:\n",
     "            return try_next(next_val)\n",

--- a/chap1/1.3.4.ipynb
+++ b/chap1/1.3.4.ipynb
@@ -1,13 +1,6 @@
 {
  "cells": [
   {
-   "cell_type": "markdown",
-   "metadata": {},
-   "source": [
-    "## 返り値としての手続き"
-   ]
-  },
-  {
    "cell_type": "code",
    "execution_count": 1,
    "metadata": {
@@ -15,7 +8,14 @@
    },
    "outputs": [],
    "source": [
-    "def average(x, y): return (x+y) / 2"
+    "from c1_3_3 import average, fixed_point"
+   ]
+  },
+  {
+   "cell_type": "markdown",
+   "metadata": {},
+   "source": [
+    "## 返り値としての手続き"
    ]
   },
   {
@@ -66,37 +66,13 @@
    },
    "outputs": [],
    "source": [
-    "def fixed_point(f, first_guess):\n",
-    "    tolerance = 1e-5\n",
-    "\n",
-    "    def is_close_enough(v1, v2):\n",
-    "        return abs(v1 - v2) < tolerance\n",
-    "\n",
-    "    def try_next(guess):\n",
-    "        next_val = f(guess)\n",
-    "        if is_close_enough(guess, next_val):\n",
-    "            return next_val\n",
-    "        else:\n",
-    "            return try_next(next_val)\n",
-    "\n",
-    "    return try_next(first_guess)"
-   ]
-  },
-  {
-   "cell_type": "code",
-   "execution_count": 6,
-   "metadata": {
-    "collapsed": true
-   },
-   "outputs": [],
-   "source": [
     "def sqrt(x):\n",
     "    return fixed_point(average_damp(lambda y: x / y), 1)"
    ]
   },
   {
    "cell_type": "code",
-   "execution_count": 7,
+   "execution_count": 6,
    "metadata": {},
    "outputs": [
     {
@@ -113,7 +89,7 @@
   },
   {
    "cell_type": "code",
-   "execution_count": 8,
+   "execution_count": 7,
    "metadata": {
     "collapsed": true
    },
@@ -125,7 +101,7 @@
   },
   {
    "cell_type": "code",
-   "execution_count": 9,
+   "execution_count": 8,
    "metadata": {},
    "outputs": [
     {
@@ -149,20 +125,19 @@
   },
   {
    "cell_type": "code",
-   "execution_count": 10,
+   "execution_count": 9,
    "metadata": {
     "collapsed": true
    },
    "outputs": [],
    "source": [
-    "def deriv(g):\n",
-    "    dx = 1e-5\n",
+    "def deriv(g, dx=1e-5):\n",
     "    return lambda x: (g(x + dx) - g(x)) / dx"
    ]
   },
   {
    "cell_type": "code",
-   "execution_count": 11,
+   "execution_count": 10,
    "metadata": {
     "collapsed": true
    },
@@ -173,7 +148,7 @@
   },
   {
    "cell_type": "code",
-   "execution_count": 12,
+   "execution_count": 11,
    "metadata": {},
    "outputs": [
     {
@@ -192,7 +167,7 @@
   },
   {
    "cell_type": "code",
-   "execution_count": 13,
+   "execution_count": 12,
    "metadata": {
     "collapsed": true
    },
@@ -204,7 +179,7 @@
   },
   {
    "cell_type": "code",
-   "execution_count": 14,
+   "execution_count": 13,
    "metadata": {
     "collapsed": true
    },
@@ -216,7 +191,7 @@
   },
   {
    "cell_type": "code",
-   "execution_count": 15,
+   "execution_count": 14,
    "metadata": {
     "collapsed": true
    },
@@ -228,7 +203,7 @@
   },
   {
    "cell_type": "code",
-   "execution_count": 16,
+   "execution_count": 15,
    "metadata": {},
    "outputs": [
     {
@@ -252,7 +227,7 @@
   },
   {
    "cell_type": "code",
-   "execution_count": 17,
+   "execution_count": 16,
    "metadata": {
     "collapsed": true
    },
@@ -264,7 +239,7 @@
   },
   {
    "cell_type": "code",
-   "execution_count": 18,
+   "execution_count": 17,
    "metadata": {
     "collapsed": true
    },
@@ -276,7 +251,7 @@
   },
   {
    "cell_type": "code",
-   "execution_count": 19,
+   "execution_count": 18,
    "metadata": {},
    "outputs": [
     {

--- a/chap1/c1_3_1.py
+++ b/chap1/c1_3_1.py
@@ -1,0 +1,16 @@
+# coding=utf-8
+"""1.3.1"""
+
+
+def summation(term, a, next_fun, b):
+    """
+    :type term: int -> float
+    :type a: int
+    :type next_fun: int -> int
+    :type b: int
+    :rtype: float
+    """
+    if a > b:
+        return 0
+    else:
+        return term(a) + summation(term, next_fun(a), next_fun, b)

--- a/chap1/c1_3_3.py
+++ b/chap1/c1_3_3.py
@@ -1,0 +1,95 @@
+# coding=utf-8
+"""1.3.3"""
+
+
+def average(x, y):
+    """
+    :type x: float
+    :type y: float
+    :rtype: float
+    """
+    return (x + y) / 2
+
+
+def is_close_enough(x, y, epsilon=1e-3):
+    """
+    :type x: float
+    :type y: float
+    :type epsilon: float
+    :rtype: bool
+    """
+    return abs(x - y) < epsilon
+
+
+def is_positive(x):
+    """
+    :type x: float
+    :rtype: bool
+    """
+    return x > 0
+
+
+def is_negative(x):
+    """
+    :type x: float
+    :rtype: bool
+    """
+    return x < 0
+
+
+def search(f, neg_point, pos_point):
+    """
+    :type f: float -> float
+    :type neg_point: float
+    :type pos_point: float
+    :rtype: float
+    """
+    midpoint = average(neg_point, pos_point)
+    if is_close_enough(neg_point, pos_point):
+        return midpoint
+    else:
+        test_value = f(midpoint)
+        if is_positive(test_value):
+            return search(f, neg_point, midpoint)
+        elif is_negative(test_value):
+            return search(f, midpoint, pos_point)
+        else:
+            return midpoint
+
+
+def half_interval_method(f, a, b):
+    """
+    :type f: float -> float
+    :type a: float
+    :type b: float
+    :rtype: float
+    """
+    a_value = f(a)
+    b_value = f(b)
+    if is_negative(a_value) and is_positive(b_value):
+        return search(f, a, b)
+    elif is_negative(b_value) and is_positive(a_value):
+        return search(f, b, a)
+    else:
+        raise ValueError('Values are not of opposite sign')
+
+
+def fixed_point(f, first_guess, tolerance=1e-5):
+    """
+    :type f: float -> float
+    :type first_guess: float
+    :type tolerance: float
+    :rtype: float
+    """
+    def try_next(guess):
+        """
+        :type guess: float
+        :rtype: float
+        """
+        next_val = f(guess)
+        if is_close_enough(guess, next_val, tolerance):
+            return next_val
+        else:
+            return try_next(next_val)
+
+    return try_next(first_guess)

--- a/chap1/c1_3_4.py
+++ b/chap1/c1_3_4.py
@@ -1,0 +1,48 @@
+# coding=utf-8
+"""1.3.4"""
+
+from c1_3_3 import average, fixed_point
+
+
+def average_damp(f):
+    """
+    :type f: float -> float
+    :rtype: float -> float
+    """
+    return lambda x: average(x, f(x))
+
+
+def deriv(g, dx=1e-5):
+    """
+    :type g: float -> float
+    :type dx: float
+    :rtype: float -> float
+    """
+    return lambda x: (g(x + dx) - g(x)) / dx
+
+
+def newton_transform(g):
+    """
+    :type g: float -> float
+    :rtype: float -> float
+    """
+    return lambda x: (x - (g(x) / deriv(g)(x)))
+
+
+def newton_method(g, guess):
+    """
+    :type g: float -> float
+    :type guess: float
+    :rtype: float
+    """
+    return fixed_point(newton_transform(g), guess)
+
+
+def fixed_point_of_transform(g, transform, guess):
+    """
+    :type g: float -> float
+    :type transform: (float -> float) -> (float -> float)
+    :type  guess: float
+    :rtype : float
+    """
+    return fixed_point(transform(g), guess)


### PR DESCRIPTION
例題を解く際にnotebookに書いた教科書の関数をまた写すのが煩わしかったので，1.3節分のみ.pyに移植．
勘違いしているかもしれないけど，数字から始まっていたりドットがついているファイル名は`import`できない気がしたので，`c1_3_1.py`のような名前にしました．
ついでに，過去に上げた教科書のまとめnotebookも微修正．